### PR TITLE
Upgrade Duplicity to 0.6.24

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -1,6 +1,10 @@
 class duplicity::packages {
   # Install the packages
   package {
-    ['duplicity', 'python-boto', 'gnupg']: ensure => present
+    ['python-boto', 'gnupg']: ensure => present
+  }
+
+  package { 'duplicity':
+    ensure => 0.6.24,
   }
 }


### PR DESCRIPTION
The version of Duplicity in use is pretty old. This fixes a few bugs, specifically one requiring the ECDSA host key be re-generated on each run.
