### PR TITLE
Expose script/cron user as param

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ define duplicity(
   $dest_key = undef,
   $folder = undef,
   $cloud = undef,
+  $user = 'root',
   $ssh_id = undef,
   $pubkey_id = undef,
   $hour = undef,
@@ -33,6 +34,7 @@ define duplicity(
     dest_key           => $dest_key,
     folder             => $folder,
     cloud              => $cloud,
+    user               => $user,
     ssh_id             => $ssh_id,
     pubkey_id          => $pubkey_id,
     full_if_older_than => $full_if_older_than,
@@ -55,7 +57,7 @@ define duplicity(
   cron { $name :
     ensure => $ensure,
     command => $spoolfile,
-    user => 'root',
+    user => $user,
     minute => $_minute,
     hour => $_hour,
   }

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -8,6 +8,7 @@ define duplicity::job(
   $dest_key = undef,
   $folder = undef,
   $cloud = undef,
+  $user = 'root',
   $ssh_id = undef,
   $pubkey_id = undef,
   $full_if_older_than = undef,
@@ -176,7 +177,7 @@ define duplicity::job(
   file { $spoolfile:
     ensure  => $ensure,
     content => template("duplicity/file-backup.sh.erb"),
-    owner   => 'root',
+    owner   => $user,
     mode    => 0700,
   }
 

--- a/spec/defines/duplicity_spec.rb
+++ b/spec/defines/duplicity_spec.rb
@@ -40,6 +40,20 @@ describe 'duplicity', :type => :define do
       .with_user('root')
   end
 
+  context "non-root user" do
+    let(:params) {
+      {
+        :user      => 'devops',
+        :directory => '/etc/',
+      }
+    }
+
+    it 'should run the cron as the specified user' do
+      should contain_cron(title) \
+        .with_user('devops')
+    end
+  end
+
   context "with defined backup time" do
 
     let(:params) {

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -30,6 +30,22 @@ describe 'duplicity::job' do
       .with_mode('0700')
   end
 
+  context "non-root user" do
+    let(:params) {
+      {
+        :user      => 'devops',
+        :directory => '/etc',
+        :spoolfile => spoolfile,
+      }
+    }
+
+    it 'should be owned and only acessible by specified user' do
+      should contain_file(spoolfile) \
+        .with_owner('devops') \
+        .with_mode('0700')
+    end
+  end
+
   context "multiple directories" do
     let(:params) {
       {


### PR DESCRIPTION
Allow the user that the cron runs as to be changed from `root`. We need this
for our offsite backups, which don't need to run as root because the files
are already tarballed with permissions recorded inside.

---

Merging against our `postcommand-hook` branch because we also need that functionality and we added `version` and `archive_directory` params there. There's basically no hope of rebasing this against upstream.
