### PR TITLE
Make --archive-dir in remove-older-than match

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -171,7 +171,7 @@ define duplicity::job(
 
   $_remove_older_than_command = $_remove_older_than ? {
     undef => '',
-    default => " && duplicity remove-older-than $_remove_older_than --verbosity warning --s3-use-new-style ${_encryption}${_ssh_options}--force $_url"
+    default => " && duplicity remove-older-than $_remove_older_than --verbosity warning --s3-use-new-style ${_encryption}${_ssh_options}--force --archive-dir ${archive_directory} $_url"
   }
 
   file { $spoolfile:

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -162,7 +162,26 @@ describe 'duplicity::job' do
 
     it "should be able to handle a specified remove-older-than time" do
       should contain_file(spoolfile) \
-        .with_content(/^duplicity .* && duplicity remove-older-than 7D.* --no-encryption --force.*/)
+        .with_content(%r{^duplicity .* --archive-dir ~/.cache/duplicity/ .*&& duplicity remove-older-than 7D .* --archive-dir ~/.cache/duplicity/ .*})
+    end
+  end
+
+  context "with defined remove-older-than and archive-dir" do
+    let(:params) {
+      {
+        :bucket            => 'somebucket',
+        :directory         => '/etc/',
+        :dest_id           => 'some_id',
+        :dest_key          => 'some_key',
+        :remove_older_than => '7D',
+        :spoolfile         => spoolfile,
+        :archive_directory => '/root/giraffe/neckbeard/',
+      }
+    }
+
+    it "should reference the same --archive-dir in both commands" do
+      should contain_file(spoolfile) \
+        .with_content(%r{^duplicity .* --archive-dir /root/giraffe/neckbeard/ .*&& duplicity remove-older-than 7D .* --archive-dir /root/giraffe/neckbeard/ .*})
     end
   end
 


### PR DESCRIPTION
When `archive_directory` and `remove_older_than` parameters are provided
then both commands in the spool file should have the same `--archive-dir`
argument.

Without this we'll be storing some cache files in two separate places. It
also seems to be the cause of Duplicity continuing to need the secret key
after we accidentally deleted our cache directory. Testing it with the same
argument for both commands stopped it prompting.