### PR TITLE
Replace 'remove_older_than' with 'remove_all_but_n_full'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@ define duplicity(
   $full_if_older_than = undef,
   $pre_command = undef,
   $post_command = undef,
-  $remove_older_than = undef,
+  $remove_all_but_n_full = undef,
   $archive_directory = undef,
 ) {
 
@@ -25,23 +25,23 @@ define duplicity(
   $spoolfile = "${duplicity::params::job_spool}/${name}.sh"
 
   duplicity::job { $name :
-    ensure             => $ensure,
-    spoolfile          => $spoolfile,
-    directory          => $directory,
-    target             => $target,
-    bucket             => $bucket,
-    dest_id            => $dest_id,
-    dest_key           => $dest_key,
-    folder             => $folder,
-    cloud              => $cloud,
-    user               => $user,
-    ssh_id             => $ssh_id,
-    pubkey_id          => $pubkey_id,
-    full_if_older_than => $full_if_older_than,
-    pre_command        => $pre_command,
-    post_command       => $post_command,
-    remove_older_than  => $remove_older_than,
-    archive_directory  => $archive_directory,
+    ensure                => $ensure,
+    spoolfile             => $spoolfile,
+    directory             => $directory,
+    target                => $target,
+    bucket                => $bucket,
+    dest_id               => $dest_id,
+    dest_key              => $dest_key,
+    folder                => $folder,
+    cloud                 => $cloud,
+    user                  => $user,
+    ssh_id                => $ssh_id,
+    pubkey_id             => $pubkey_id,
+    full_if_older_than    => $full_if_older_than,
+    pre_command           => $pre_command,
+    post_command          => $post_command,
+    remove_all_but_n_full => $remove_all_but_n_full,
+    archive_directory     => $archive_directory,
   }
 
   $_hour = $hour ? {

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -14,7 +14,7 @@ define duplicity::job(
   $full_if_older_than = undef,
   $pre_command = undef,
   $post_command = undef,
-  $remove_older_than = undef,
+  $remove_all_but_n_full = undef,
   $archive_directory = '~/.cache/duplicity/',
 ) {
 
@@ -93,9 +93,9 @@ define duplicity::job(
     default => $post_command,
   }
 
-  $_remove_older_than = $remove_older_than ? {
-    undef   => $duplicity::params::remove_older_than,
-    default => $remove_older_than,
+  $_remove_all_but_n_full = $remove_all_but_n_full ? {
+    undef   => $duplicity::params::remove_all_but_n_full,
+    default => $remove_all_but_n_full,
   }
 
   $_ssh_options = $_ssh_id ? {
@@ -170,9 +170,9 @@ define duplicity::job(
     }
   }
 
-  $_remove_older_than_command = $_remove_older_than ? {
+  $_remove_all_but_n_full_command = $_remove_all_but_n_full ? {
     undef => '',
-    default => " && duplicity remove-older-than $_remove_older_than --verbosity warning --s3-use-new-style ${_encryption}${_ssh_options}--force --archive-dir ${archive_directory} $_url"
+    default => " && duplicity remove-all-but-n-full $_remove_all_but_n_full --verbosity warning --s3-use-new-style ${_encryption}${_ssh_options}--force --archive-dir ${archive_directory} $_url"
   }
 
   file { $spoolfile:

--- a/manifests/monitored_job.pp
+++ b/manifests/monitored_job.pp
@@ -12,7 +12,7 @@ define duplicity::monitored_job(
   $minute = undef,
   $full_if_older_than = undef,
   $pre_command = undef,
-  $remove_older_than = undef,
+  $remove_all_but_n_full = undef,
   $execution_timeout
 )
 {
@@ -34,7 +34,7 @@ define duplicity::monitored_job(
     pubkey_id => $pubkey_id,
     full_if_older_than => $full_if_older_than,
     pre_command => $pre_command,
-    remove_older_than => $remove_older_than,
+    remove_all_but_n_full => $remove_all_but_n_full,
   }
 
   $_hour = $hour ? {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class duplicity::params(
   $hour                  = $duplicity::defaults::hour,
   $minute                = $duplicity::defaults::minute,
   $full_if_older_than    = $duplicity::defaults::full_if_older_than,
-  $remove_older_than     = undef,
+  $remove_all_but_n_full = undef,
   $job_spool = $duplicity::defaults::job_spool
 ) inherits duplicity::defaults {
 

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -147,7 +147,7 @@ describe 'duplicity::job' do
     end
   end
 
-  context "with defined remove-older-than" do
+  context "with defined remove-all-but-n-full" do
 
     let(:params) {
       {
@@ -155,25 +155,25 @@ describe 'duplicity::job' do
         :directory          => '/etc/',
         :dest_id            => 'some_id',
         :dest_key           => 'some_key',
-        :remove_older_than => '7D',
+        :remove_all_but_n_full => '7D',
         :spoolfile => spoolfile,
       }
     }
 
-    it "should be able to handle a specified remove-older-than time" do
+    it "should be able to handle a specified remove-all-but-n-full time" do
       should contain_file(spoolfile) \
-        .with_content(%r{^duplicity .* --archive-dir ~/.cache/duplicity/ .*&& duplicity remove-older-than 7D .* --archive-dir ~/.cache/duplicity/ .*})
+        .with_content(%r{^duplicity .* --archive-dir ~/.cache/duplicity/ .*&& duplicity remove-all-but-n-full 7D .* --archive-dir ~/.cache/duplicity/ .*})
     end
   end
 
-  context "with defined remove-older-than and archive-dir" do
+  context "with defined remove-all-but-n-full and archive-dir" do
     let(:params) {
       {
         :bucket            => 'somebucket',
         :directory         => '/etc/',
         :dest_id           => 'some_id',
         :dest_key          => 'some_key',
-        :remove_older_than => '7D',
+        :remove_all_but_n_full => '7D',
         :spoolfile         => spoolfile,
         :archive_directory => '/root/giraffe/neckbeard/',
       }
@@ -181,7 +181,7 @@ describe 'duplicity::job' do
 
     it "should reference the same --archive-dir in both commands" do
       should contain_file(spoolfile) \
-        .with_content(%r{^duplicity .* --archive-dir /root/giraffe/neckbeard/ .*&& duplicity remove-older-than 7D .* --archive-dir /root/giraffe/neckbeard/ .*})
+        .with_content(%r{^duplicity .* --archive-dir /root/giraffe/neckbeard/ .*&& duplicity remove-all-but-n-full 7D .* --archive-dir /root/giraffe/neckbeard/ .*})
     end
   end
 
@@ -377,12 +377,12 @@ describe 'duplicity::job' do
 
     let(:params) {
       {
-        :target            => 'ssh://someserver//some/dir',
-        :ssh_id            => '/etc/duplicity/id_rsa',
-        :cloud             => false,
-        :bucket            => false,
-        :directory         => '/root/mysqldump',
-        :remove_older_than => '1Y',
+        :target                => 'ssh://someserver//some/dir',
+        :ssh_id                => '/etc/duplicity/id_rsa',
+        :cloud                 => false,
+        :bucket                => false,
+        :directory             => '/root/mysqldump',
+        :remove_all_but_n_full => '1Y',
         :spoolfile => spoolfile,
       }
     }
@@ -391,7 +391,7 @@ describe 'duplicity::job' do
       should contain_file(spoolfile) \
       .with_content(/ssh:\/\/someserver\/\/some\/dir/)
       .with_content(/^duplicity .* --ssh-options -oIdentityFile=\'\/etc\/duplicity\/id_rsa\'/)
-      .with_content(/&& duplicity remove-older-than .* --ssh-options -oIdentityFile=\'\/etc\/duplicity\/id_rsa\'/)
+      .with_content(/&& duplicity remove-all-but-n-full .* --ssh-options -oIdentityFile=\'\/etc\/duplicity\/id_rsa\'/)
     end
   end
 end

--- a/templates/file-backup.sh.erb
+++ b/templates/file-backup.sh.erb
@@ -6,5 +6,5 @@ set -o pipefail
 <%= var %>
 <% end-%>
 <%= @_pre_command %>
-duplicity --verbosity warning --no-print-statistics --full-if-older-than <%= @_full_if_older_than -%> --s3-use-new-style <%= @_encryption -%><%= @_ssh_options -%><% _directories.each do |dir| %>--include '<%= dir -%>' <% end %>--exclude '**' --archive-dir <%= @archive_directory -%> / '<%= @_url -%>'<%= @_remove_older_than_command %>
+duplicity --verbosity warning --no-print-statistics --full-if-older-than <%= @_full_if_older_than -%> --s3-use-new-style <%= @_encryption -%><%= @_ssh_options -%><% _directories.each do |dir| %>--include '<%= dir -%>' <% end %>--exclude '**' --archive-dir <%= @archive_directory -%> / '<%= @_url -%>'<%= @_remove_all_but_n_full_command %>
 <%= @_post_command %>


### PR DESCRIPTION
Replacing the 'remove_older_than' option in our Duplicity configuration with
'remove_all_but_n' to make our intentions more explicit when we move to
making backups weekly.

Also fixes up tests and templates.