### PR TITLE
Use ensure_packages for installing packages

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -1,15 +1,15 @@
 class duplicity::packages (
   $version = 'present',
   ) {
+
   # Install the packages
-  package {[
-            'python-paramiko',
-            'python-gobject-2',
-            'python-boto',
-            'gnupg'
-            ]:
-          ensure => present
-  }
+  ensure_packages([
+    'python-paramiko',
+    'python-gobject-2',
+    'python-boto',
+    'gnupg',
+  ])
+
   package {'duplicity':
     ensure => $version,
   }


### PR DESCRIPTION
This prevents "duplicate class" errors.