### PR TITLE
Make the lookup use an instance variable rather than a local one.

### DIFF
--- a/templates/file-backup.sh.erb
+++ b/templates/file-backup.sh.erb
@@ -6,5 +6,5 @@ set -o pipefail
 export <%= var %>
 <% end-%>
 <%= @_pre_command %>
-duplicity --verbosity warning --no-print-statistics --full-if-older-than <%= @_full_if_older_than -%> --s3-use-new-style <%= @_encryption -%><%= @_ssh_options -%><% _directories.each do |dir| %>--include '<%= dir -%>' <% end %>--exclude '**' --archive-dir <%= @archive_directory -%> / '<%= @_url -%>'<%= @_remove_all_but_n_full_command %>
+duplicity --verbosity warning --no-print-statistics --full-if-older-than <%= @_full_if_older_than -%> --s3-use-new-style <%= @_encryption -%><%= @_ssh_options -%><% @_directories.each do |dir| %>--include '<%= dir -%>' <% end %>--exclude '**' --archive-dir <%= @archive_directory -%> / '<%= @_url -%>'<%= @_remove_all_but_n_full_command %>
 <%= @_post_command %>


### PR DESCRIPTION
This stops the `Variable access via '_directories' is deprecated.
Use '@_directories' instead.` warnings.