### PR TITLE
Remove unrequired variables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,6 @@ gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.8.7'
 gem 'rspec-puppet', '2.4.0'
 gem 'puppet-lint', '1.1.0'
 gem 'puppetlabs_spec_helper', '1.1.1'
+
+# older version required for ruby 1.9 compat, as it is pulled in as dependency of puppet, this has to be carried by the module
+gem 'json_pure', '<= 2.0.1'

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -16,9 +16,6 @@ define duplicity::job(
   $post_command = undef,
   $remove_all_but_n_full = undef,
   $archive_directory = '~/.cache/duplicity/',
-  $weekday = undef,
-  $hour = undef,
-  $minute = undef,
 ) {
 
   include duplicity::params
@@ -69,21 +66,6 @@ define duplicity::job(
   $_pubkey_id = $pubkey_id ? {
     undef => $duplicity::params::pubkey_id,
     default => $pubkey_id
-  }
-
-  $_weekday = $weekday ? {
-    undef => $duplicity::params::weekday,
-    default => $weekday
-  }
-
-  $_hour = $hour ? {
-    undef => $duplicity::params::hour,
-    default => $hour
-  }
-
-  $_minute = $minute ? {
-    undef => $duplicity::params::minute,
-    default => $minute
   }
 
   $_full_if_older_than = $full_if_older_than ? {


### PR DESCRIPTION
I cannot see where these are used in this defined type. In the main ::duplicity defined type (init.pp) these are used to create a cron job, but in the specific job defined type they are simply not referenced again.

I believe they were inadvertently moved across in 4eb6a7009b3eeb84a02e81d8bb765dff2d8a2c37