### PR TITLE
Add multi-processing and part chunk size opts

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,8 @@ define duplicity(
   $post_command = undef,
   $remove_all_but_n_full = undef,
   $archive_directory = undef,
+  $s3_use_multiprocessing = undef,
+  $s3_multipart_chunk_size = undef,
 ) {
 
   include duplicity::params
@@ -26,23 +28,25 @@ define duplicity(
   $spoolfile = "${duplicity::params::job_spool}/${name}.sh"
 
   duplicity::job { $name :
-    ensure                => $ensure,
-    spoolfile             => $spoolfile,
-    directory             => $directory,
-    target                => $target,
-    bucket                => $bucket,
-    dest_id               => $dest_id,
-    dest_key              => $dest_key,
-    folder                => $folder,
-    cloud                 => $cloud,
-    user                  => $user,
-    ssh_id                => $ssh_id,
-    pubkey_id             => $pubkey_id,
-    full_if_older_than    => $full_if_older_than,
-    pre_command           => $pre_command,
-    post_command          => $post_command,
-    remove_all_but_n_full => $remove_all_but_n_full,
-    archive_directory     => $archive_directory,
+    ensure                  => $ensure,
+    spoolfile               => $spoolfile,
+    directory               => $directory,
+    target                  => $target,
+    bucket                  => $bucket,
+    dest_id                 => $dest_id,
+    dest_key                => $dest_key,
+    folder                  => $folder,
+    cloud                   => $cloud,
+    user                    => $user,
+    ssh_id                  => $ssh_id,
+    pubkey_id               => $pubkey_id,
+    full_if_older_than      => $full_if_older_than,
+    pre_command             => $pre_command,
+    post_command            => $post_command,
+    remove_all_but_n_full   => $remove_all_but_n_full,
+    archive_directory       => $archive_directory,
+    s3_use_multiprocessing  => $s3_use_multiprocessing,
+    s3_multipart_chunk_size => $s3_multipart_chunk_size,
   }
 
   $_weekday = $weekday ? {

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -16,6 +16,8 @@ define duplicity::job(
   $post_command = undef,
   $remove_all_but_n_full = undef,
   $archive_directory = '~/.cache/duplicity/',
+  $s3_use_multiprocessing = undef,
+  $s3_multipart_chunk_size = undef,
 ) {
 
   include duplicity::params
@@ -93,6 +95,17 @@ define duplicity::job(
     default => " --ssh-options -oIdentityFile='${_ssh_id}' "
   }
 
+  $_s3_use_multiprocessing = $s3_use_multiprocessing ? {
+    undef => '',
+    false => '',
+    true  => '--s3-use-multiprocessing ',
+  }
+
+  $_s3_multipart_chunk_size = $s3_multipart_chunk_size ? {
+    undef => '',
+    default => "--s3-multipart-chunk-size=${s3_multipart_chunk_size} ",
+  }
+
   # convert the old cloud, bucket and target parameters into the new target parameter
   if (! $_target) {
 
@@ -162,7 +175,7 @@ define duplicity::job(
 
   $_remove_all_but_n_full_command = $_remove_all_but_n_full ? {
     undef => '',
-    default => " && duplicity remove-all-but-n-full ${_remove_all_but_n_full} --verbosity warning --s3-use-new-style ${_encryption}${_ssh_options}--force --archive-dir ${archive_directory} ${_url}"
+    default => " && duplicity remove-all-but-n-full ${_remove_all_but_n_full} --verbosity warning --s3-use-new-style ${_s3_use_multiprocessing}${_s3_multipart_chunk_size}${_encryption}${_ssh_options}--force --archive-dir ${archive_directory} ${_url}"
   }
 
   file { $spoolfile:

--- a/templates/file-backup.sh.erb
+++ b/templates/file-backup.sh.erb
@@ -6,5 +6,5 @@ set -o pipefail
 export <%= var %>
 <% end-%>
 <%= @_pre_command %>
-duplicity --verbosity warning --no-print-statistics --full-if-older-than <%= @_full_if_older_than -%> --s3-use-new-style <%= @_encryption -%><%= @_ssh_options -%><% @_directories.each do |dir| %>--include '<%= dir -%>' <% end %>--exclude '**' --archive-dir <%= @archive_directory -%> / '<%= @_url -%>'<%= @_remove_all_but_n_full_command %>
+duplicity --verbosity warning --no-print-statistics --full-if-older-than <%= @_full_if_older_than -%> --s3-use-new-style <%= @_s3_use_multiprocessing %><%= @_s3_multipart_chunk_size %><%= @_encryption -%><%= @_ssh_options -%><% @_directories.each do |dir| %>--include '<%= dir -%>' <% end %>--exclude '**' --archive-dir <%= @archive_directory -%> / '<%= @_url -%>'<%= @_remove_all_but_n_full_command %>
 <%= @_post_command %>


### PR DESCRIPTION
This adds the two duplicity options:

```
--s3-use-multiprocessing
--s3-multipart-chunk-size=number
```

When multiprocessing is enabled, it will upload files to S3 using multiple processes by chunking files into parts. The number of processes is defaulted to the number of detected CPUs on the system.

The chunk size number is defaulted to 25MB, but this can be changed to a larger or smaller size depending on the requirement. Smaller chunks can be to retrieve for a restore, but it will create a larger number of files.

The maximum chunk size of S3 is 5GB.