### PR TITLE
Add multipart max processes option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,7 @@ define duplicity(
   $archive_directory = undef,
   $s3_use_multiprocessing = undef,
   $s3_multipart_chunk_size = undef,
+  $s3_multipart_max_procs = undef,
 ) {
 
   include duplicity::params
@@ -47,6 +48,7 @@ define duplicity(
     archive_directory       => $archive_directory,
     s3_use_multiprocessing  => $s3_use_multiprocessing,
     s3_multipart_chunk_size => $s3_multipart_chunk_size,
+    s3_multipart_max_procs  => $s3_multipart_max_procs,
   }
 
   $_weekday = $weekday ? {

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -18,6 +18,7 @@ define duplicity::job(
   $archive_directory = '~/.cache/duplicity/',
   $s3_use_multiprocessing = undef,
   $s3_multipart_chunk_size = undef,
+  $s3_multipart_max_procs = undef,
 ) {
 
   include duplicity::params
@@ -106,6 +107,11 @@ define duplicity::job(
     default => "--s3-multipart-chunk-size=${s3_multipart_chunk_size} ",
   }
 
+  $_s3_multipart_max_procs = $s3_multipart_max_procs ? {
+    undef => '',
+    default => "--s3-multipart-max-procs=${s3_multipart_max_procs} ",
+  }
+
   # convert the old cloud, bucket and target parameters into the new target parameter
   if (! $_target) {
 
@@ -175,7 +181,7 @@ define duplicity::job(
 
   $_remove_all_but_n_full_command = $_remove_all_but_n_full ? {
     undef => '',
-    default => " && duplicity remove-all-but-n-full ${_remove_all_but_n_full} --verbosity warning --s3-use-new-style ${_s3_use_multiprocessing}${_s3_multipart_chunk_size}${_encryption}${_ssh_options}--force --archive-dir ${archive_directory} ${_url}"
+    default => " && duplicity remove-all-but-n-full ${_remove_all_but_n_full} --verbosity warning --s3-use-new-style ${_s3_use_multiprocessing}${_s3_multipart_chunk_size}${_s3_multipart_max_procs}${_encryption}${_ssh_options}--force --archive-dir ${archive_directory} ${_url}"
   }
 
   file { $spoolfile:

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -182,6 +182,24 @@ describe 'duplicity::job' do
     end
   end
 
+  context "with s3_multipart_max_procs set to 4" do
+    let(:params) {
+      {
+        :bucket       => 'somebucket',
+        :directory    => '/etc/',
+        :dest_id  => 'some_id',
+        :dest_key => 'some_key',
+        :spoolfile => spoolfile,
+        :s3_multipart_max_procs => 4,
+      }
+    }
+
+    it "adds a spoolfile which contains --s3-multipart-max-procs=4" do
+      should contain_file(spoolfile) \
+        .with_content(/^duplicity --verbosity warning --no-print-statistics --full-if-older-than 30D --s3-use-new-style --s3-multipart-max-procs=4 --no-encryption --include '\/etc\/' --exclude '\*\*' --archive-dir ~\/.cache\/duplicity\/ \/ 's3\+http:\/\/somebucket\/#{fqdn}\/some_backup_name\/'$/)
+    end
+  end
+
   context "with defined force full-backup" do
 
     let(:params) {
@@ -274,6 +292,25 @@ describe 'duplicity::job' do
     it "should set s3_multipart_chunk_size to 250 in both files" do
       should contain_file(spoolfile) \
         .with_content(%r{duplicity .* --s3-multipart-chunk-size=250 .*&& duplicity remove-all-but-n-full 7 .* --s3-multipart-chunk-size=250 .*})
+    end
+  end
+
+  context "with defined remove-all-but-n-full and s3_multipart_max_procs set to 4" do
+    let(:params) {
+      {
+        :bucket            => 'somebucket',
+        :directory         => '/etc/',
+        :dest_id           => 'some_id',
+        :dest_key          => 'some_key',
+        :remove_all_but_n_full => '7',
+        :spoolfile         => spoolfile,
+        :s3_multipart_max_procs => 4,
+      }
+    }
+
+    it "should set s3_multipart_max_procs to 4 in both files" do
+      should contain_file(spoolfile) \
+        .with_content(%r{duplicity .* --s3-multipart-max-procs=4 .*&& duplicity remove-all-but-n-full 7 .* --s3-multipart-max-procs=4 .*})
     end
   end
 

--- a/templates/file-backup.sh.erb
+++ b/templates/file-backup.sh.erb
@@ -6,5 +6,5 @@ set -o pipefail
 export <%= var %>
 <% end-%>
 <%= @_pre_command %>
-duplicity --verbosity warning --no-print-statistics --full-if-older-than <%= @_full_if_older_than -%> --s3-use-new-style <%= @_s3_use_multiprocessing %><%= @_s3_multipart_chunk_size %><%= @_encryption -%><%= @_ssh_options -%><% @_directories.each do |dir| %>--include '<%= dir -%>' <% end %>--exclude '**' --archive-dir <%= @archive_directory -%> / '<%= @_url -%>'<%= @_remove_all_but_n_full_command %>
+duplicity --verbosity warning --no-print-statistics --full-if-older-than <%= @_full_if_older_than -%> --s3-use-new-style <%= @_s3_use_multiprocessing %><%= @_s3_multipart_chunk_size %><%= @_s3_multipart_max_procs %><%= @_encryption -%><%= @_ssh_options -%><% @_directories.each do |dir| %>--include '<%= dir -%>' <% end %>--exclude '**' --archive-dir <%= @archive_directory -%> / '<%= @_url -%>'<%= @_remove_all_but_n_full_command %>
 <%= @_post_command %>


### PR DESCRIPTION
This option is only available in later versions of duplicity. It allows a user to set the maximum available processes for uploading chunks to S3. This is useful if you want to ensure that your system doesn't spawn hundreds of processes.